### PR TITLE
Fixed the nickname usage, ordering of parameters to emit_to_room() and improper echo to the sender

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -9,14 +9,14 @@ from socketio.mixins import RoomsMixin, BroadcastMixin
 class ChatNamespace(BaseNamespace, RoomsMixin, BroadcastMixin):
     def on_nickname(self, nickname):
         self.environ['nicknames'].append(nickname)
-        #self.socket.session = nickname
-        self.broadcast_event('anouncement', '%s has connected' % nickname)
+        self.socket.session['nickname'] = nickname
+        self.broadcast_event('announcement', '%s has connected' % nickname)
         self.broadcast_event('nicknames', self.environ['nicknames'])
         # Just have them join a default-named room
         self.join('main_room')
 
     def on_user_message(self, msg):
-        self.emit_to_room('msg_to_room', msg, 'main_room')
+        self.emit_to_room('main_room', 'msg_to_room', self.socket.session['nickname'], msg)
 
     def recv_message(self, message):
         print "PING!!!", message

--- a/socketio/mixins.py
+++ b/socketio/mixins.py
@@ -33,7 +33,7 @@ class RoomsMixin(object):
         for sessid, socket in self.socket.server.sockets.iteritems():
             if 'rooms' not in socket.session:
                 continue
-            if room_name in socket.session['rooms']:
+            if room_name in socket.session['rooms'] and self.socket != socket:
                 socket.send_packet(pkt)
 
 


### PR DESCRIPTION
Additional changes to fix #12 
- Nicknames are now echo'd properly in the chat window.
- Messages from one user to another are transmitted with emit_to_room()
- Upon new users joining, Nicknames are now announced

Thanks go to @mruser
