### PR TITLE
remove closed socket from sockets list when socket.kill() is called

### DIFF
--- a/socketio/virtsocket.py
+++ b/socketio/virtsocket.py
@@ -203,6 +203,7 @@ class Socket(object):
             self.server_queue.put_nowait(None)
             self.client_queue.put_nowait(None)
             self.disconnect()
+            self.server.sockets.pop(self.sessid)
             # gevent.kill(self.wsgi_app_greenlet)
         else:
             pass  # Fail silently


### PR DESCRIPTION
When disconnecting from client the virtsocket is not popped from server.sockets. 

So for example if we refresh the screen several sockets are created and not 
removed from the sockets list. 
