### PR TITLE
Freeze gevent-websocket version number.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license="BSD",
     url="https://github.com/abourget/gevent-socketio",
     download_url="https://github.com/abourget/gevent-socketio",
-    install_requires=("gevent-websocket",),
+    install_requires=("gevent-websocket==0.3.6",),
     setup_requires=("versiontools >= 1.7",),
     packages=find_packages(exclude=["examples", "tests"]),
     classifiers=[


### PR DESCRIPTION
By specifying an exact version of gevent-websocket we increase the likelihood that the current master of gevent-socketio is working. gevent-websocket changes somewhat frequently, and often breaks compatability when it does so.  Having a stable gevent-socketio = awesome! :)
