### PR TITLE
Exit watcher after disconnecting.

### DIFF
--- a/socketio/virtsocket.py
+++ b/socketio/virtsocket.py
@@ -393,6 +393,7 @@ class Socket(object):
                 gevent.killall(self.jobs)
                 for ns_name, ns in list(self.active_ns.iteritems()):
                     ns.recv_disconnect()
+                break
 
     def _spawn_watcher(self):
         job = gevent.spawn(self._watcher)


### PR DESCRIPTION
This fixes #55 -- sockets and related objects are leaking because the watcher greenlet is not exiting on disconnect.
