### PR TITLE
Remove dependency on handler.response_headers_list 

### DIFF
--- a/socketio/transports.py
+++ b/socketio/transports.py
@@ -19,9 +19,8 @@ class BaseTransport(object):
         self.handler = handler
 
     def write(self, data=""):
-        if 'Content-Length' not in self.handler.response_headers_list:
+        if 'Content-Length' not in [x[0] for x in self.handler.response_headers]:
             self.handler.response_headers.append(('Content-Length', len(data)))
-            self.handler.response_headers_list.append('Content-Length')
 
         self.handler.write(data)
 
@@ -30,7 +29,6 @@ class BaseTransport(object):
             headers.append(self.content_type)
 
         headers.extend(self.headers)
-        #print headers
         self.handler.start_response(status, headers, **kwargs)
 
 


### PR DESCRIPTION
response_headers_list was removed in gevent commit https://github.com/schmir/gevent/commit/c5597248095243089a0f6633f45fc033676efd2d This breaks several transports for those of us using the latest version of gevent. 

See: https://bitbucket.org/Jeffrey/gevent-socketio/pull-request/10/remove-dependence-on
