### PR TITLE
Fixing on disconnect memory leaks and socket closing. 

### DIFF
--- a/socketio/sgunicorn.py
+++ b/socketio/sgunicorn.py
@@ -59,4 +59,4 @@ class GeventSocketIOWorker(GeventSocketIOBaseWorker):
     # was a configuration option, will probably end up how this implemented,
     # for now this is just a proof of concept to make sure this will work
     resource = 'socket.io'
-    policy_server = False  # Don't run the flash policy server
+    policy_server = True  # Don't run the flash policy server

--- a/socketio/transports.py
+++ b/socketio/transports.py
@@ -1,7 +1,7 @@
 import gevent
 import urllib
 import urlparse
-
+from geventwebsocket import WebSocketError
 from gevent.queue import Empty
 
 
@@ -237,8 +237,10 @@ class WebsocketTransport(BaseTransport):
 
                 if message is None:
                     break
-
-                websocket.send(message)
+                try:
+                    websocket.send(message)
+                except WebSocketError:
+                    socket.disconnect()
 
         def read_from_ws():
             while True:

--- a/socketio/virtsocket.py
+++ b/socketio/virtsocket.py
@@ -222,11 +222,12 @@ class Socket(object):
             self.state = self.STATE_DISCONNECTING
             self.server_queue.put_nowait(None)
             self.client_queue.put_nowait(None)
-            self.disconnect()
+            if len(self.active_ns) > 0:
+                self.disconnect()
 
             if self.sessid in self.server.sockets:
                 self.server.sockets.pop(self.sessid)
-                
+         
             gevent.killall(self.jobs)
         else:
             raise Exception('Not connected')
@@ -312,6 +313,9 @@ class Socket(object):
         """
         if namespace in self.active_ns:
             del self.active_ns[namespace]
+
+        if len(self.active_ns) == 0:
+            self.kill()
 
     def send_packet(self, pkt):
         """Low-level interface to queue a packet on the wire (encoded as wire


### PR DESCRIPTION
This is a fix for #78 issue. I 've tested it with gunicorn's worker and various browsers. It stops all namespace jobs and socket jobs when a client disconnects either by issuing socket.disconnect() or moving away from the page which initiated the websocket connection.
I' ve checked with "netstat" for open sockets and with "ps -eo rss" for memory leaks. Maybe further tests with different setups are needed to verify fixing it.

I have also changed gunicorn's worker to start the policy-server by default. This way more browsers are able to use websockets and don't fall back to xhr-polling.

Best regards,
Andreas
