### PR TITLE
Updates RC version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ class PyTest(TestCommand):
 
 setup(
     name="gevent-socketio",
-    version="0.3.5-rc2",
+    version="0.3.5-rc3",
     description=(
         "SocketIO server based on the Gevent pywsgi server, "
         "a Python network library"),


### PR DESCRIPTION
Hello, 

The version registered with Python Package Index is set at `0.3.5-rc2` but does not include the fix in [this commit](https://github.com/abourget/gevent-socketio/commit/a8b6d931ae57faa6386e91fb611e56d50b4255a0) related to overriding JSON serialization.  The version on Github is also `0.3.5-rc2' but includes the fix in #74.  

Without the version increment, specifying the Github account in a setup.py file doesn't effectively force setuptools to use the git version, setuptools still pulls the version on the package index instead, and passing `json_dumps` to `socketio_manage` throws an error:

```
TypeError: socketio_manage() got an unexpected keyword argument 'json_dumps'
```

In this mighty pull request, I've patched `setup.py` to report `version="0.3.5-rc3"`.

Thanks!
Aaron
