### PR TITLE
Fix for exception in xhr-longpoll transport on gevent 1.0bX

### DIFF
--- a/socketio/transports.py
+++ b/socketio/transports.py
@@ -24,8 +24,8 @@ class BaseTransport(object):
             if 'Content-Length' not in self.handler.response_headers_list:
                 self.handler.response_headers.append(('Content-Length', len(data)))
                 self.handler.response_headers_list.append('Content-Length')
-        elif self.handler.provided_content_length is None:
-            # Gevent bitbucket
+        elif not hasattr(self.handler, 'provided_content_length'):
+            # Gevent 1.0bX
             l = len(data)
             self.handler.provided_content_length = l
             self.handler.response_headers.append(('Content-Length', l))


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0b2-py2.7-linux-x86_64.egg/gevent/greenlet.py", line 328, in run
    result = self._run(_self.args, *_self.kwargs)
  File "/usr/local/lib/python2.7/dist-packages/gevent_socketio-0.3.5_rc3-py2.7.egg/socketio/server.py", line 75, in handle
    handler.handle()
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0b2-py2.7-linux-x86_64.egg/gevent/pywsgi.py", line 184, in handle
    result = self.handle_one_request()
  File "/usr/local/lib/python2.7/dist-packages/gevent-1.0b2-py2.7-linux-x86_64.egg/gevent/pywsgi.py", line 316, in handle_one_request
    self.handle_one_response()
  File "/usr/local/lib/python2.7/dist-packages/gevent_socketio-0.3.5_rc3-py2.7.egg/socketio/handler.py", line 123, in handle_one_response
    jobs = self.transport.connect(socket, request_method)
  File "/usr/local/lib/python2.7/dist-packages/gevent_socketio-0.3.5_rc3-py2.7.egg/socketio/transports.py", line 146, in connect
    return getattr(self, request_method.lower())(socket)
  File "/usr/local/lib/python2.7/dist-packages/gevent_socketio-0.3.5_rc3-py2.7.egg/socketio/transports.py", line 60, in get
    self.write(payload)
  File "/usr/local/lib/python2.7/dist-packages/gevent_socketio-0.3.5_rc3-py2.7.egg/socketio/transports.py", line 178, in write
    super(JSONPolling, self).write("io.j[%s]('%s');" % (i, data))
  File "/usr/local/lib/python2.7/dist-packages/gevent_socketio-0.3.5_rc3-py2.7.egg/socketio/transports.py", line 27, in write
    elif self.handler.provided_content_length is None:
AttributeError: 'SocketIOHandler' object has no attribute 'provided_content_length'
