### PR TITLE
Return decorated class in Django namespace decorator

### DIFF
--- a/socketio/sdjango.py
+++ b/socketio/sdjango.py
@@ -8,12 +8,15 @@ from django.views.decorators.csrf import csrf_exempt
 
 SOCKETIO_NS = {}
 
+
 class namespace(object):
     def __init__(self, name=''):
         self.name = name
 
     def __call__(self, handler):
         SOCKETIO_NS[self.name] = handler
+        return handler
+
 
 @csrf_exempt
 def socketio(request):


### PR DESCRIPTION
I just added a return in the `namespace` decorator in sdjango so that I can import it from other places (so I can use it in my tests).  Thanks :)
