### PR TITLE
Fix incompatibility between gevent and gevent-socketio

### DIFF
--- a/socketio/sgunicorn.py
+++ b/socketio/sgunicorn.py
@@ -39,6 +39,8 @@ class GeventSocketIOBaseWorker(GeventPyWSGIWorker):
         super(GeventSocketIOBaseWorker, self).__init__(age, ppid, socket, app, timeout, cfg, log)
 
     def run(self):
+        if not hasattr(self, 'socket'):
+            self.socket = self.sockets[0]
         self.socket.setblocking(1)
         pool = Pool(self.worker_connections)
         self.server_class.base_env['wsgi.multiprocess'] = \


### PR DESCRIPTION
When running the `pip` version of `gevent-socketio`, I notice the following exception:

```
Traceback (most recent call last):
  File "/Users/jarcher/Documents/2013/02-February/Plutocrat/lib/python2.7/site-packages/gunicorn/arbiter.py", line 485, in spawn_worker
    worker.init_process()
  File "/Users/jarcher/Documents/2013/02-February/Plutocrat/lib/python2.7/site-packages/gunicorn/workers/ggevent.py", line 131, in init_process
    super(GeventWorker, self).init_process()
  File "/Users/jarcher/Documents/2013/02-February/Plutocrat/lib/python2.7/site-packages/gunicorn/workers/base.py", line 104, in init_process
    self.run()
  File "/Users/jarcher/Documents/2013/02-February/Plutocrat/lib/python2.7/site-packages/socketio/sgunicorn.py", line 15, in run
    self.socket.setblocking(1)
AttributeError: 'GeventSocketIOWorker' object has no attribute 'socket'
```

I believe that the bugfix attached prevents this exception and avoids backwards incompatibility.
