### PR TITLE
allow resources to be a prefix

### DIFF
--- a/socketio/handler.py
+++ b/socketio/handler.py
@@ -46,7 +46,7 @@ class SocketIOHandler(WSGIHandler):
 
 
     def _do_handshake(self, tokens):
-        if tokens["resource"] != self.server.resource:
+        if not tokens["resource"].startswith(self.server.resource):
             self.log_error("socket.io URL mismatch")
         else:
             socket = self.server.get_socket()


### PR DESCRIPTION
Well, sometimes people may need server resource to be a prefix, like `/socket.io/v1.0/`, where `v1.0` might be handled by any framework URL router and passed to appreciated socket.io namespace. So our  server initialization looks like:

    address = 'localhost', 9100
    server = SocketIOServer(
        address, application,
        resource='socket.io', # instead of resource='socket.io/v1.1',
    )

There was a [merged ticket](https://github.com/LearnBoost/socket.io/pull/744) on socket.io that make it possible to use a regexp on resource URLs. But since *the implementation was hard to explain for me, I thought it might be a bad idea*. So I came up with a one line modification that it was damn easy. 

I'm curios about what people say if it should be regex allowed or this `.startswith` solution is just fine.