### PR TITLE
Mention event handler magic earlier in docs

### DIFF
--- a/socketio/namespace.py
+++ b/socketio/namespace.py
@@ -27,6 +27,10 @@ class BaseNamespace(object):
       def on_my_second_event(self, whatever):
           print "This holds the first arg that was passed", whatever
 
+    Handlers are automatically dispatched based on the name of the incoming
+    event. For example, a 'user message' event will be handled by
+    ``on_user_message()``. To change this, override :meth:`process_event`.
+    
     We can also access the full packet directly by making an event handler
     that accepts a single argument named 'packet':
 


### PR DESCRIPTION
There may be a better way to phrase this, but the docstring left me wondering how one was supposed to bind a method to an event.
