### PR TITLE
Fixing typo in tests (decimal comparison)

### DIFF
--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -80,7 +80,7 @@ class TestEncodeMessage(TestCase):
                                   'id': 1,
                                   'ack': 'data',
                                   'endpoint': '',
-                                  'data': {'a' : decimal.Decimal('%f' % (0.5))}
+                                  'data': {'a' : decimal.Decimal('%0.1f' % (0.5))}
                                   })
         self.assertEqual(encoded_message, '4:1+::{"a":0.5}')
 


### PR DESCRIPTION
Pretty minor, but was failing for me with python 2.7.1.
