### PR TITLE
Prevent leaking of namespace processes when a socket is closed by a sock...

### DIFF
--- a/socketio/namespace.py
+++ b/socketio/namespace.py
@@ -492,8 +492,12 @@ class BaseNamespace(object):
             packet = {"type": "disconnect",
                       "endpoint": self.ns_name}
             self.socket.send_packet(packet)
-        self.socket.remove_namespace(self.ns_name)
-        self.kill_local_jobs()
+        # remove_namespace might throw GreenletExit so
+        # kill_local_jobs must be in finally
+        try:
+            self.socket.remove_namespace(self.ns_name)
+        finally:
+            self.kill_local_jobs()
 
     def kill_local_jobs(self):
         """Kills all the jobs spawned with BaseNamespace.spawn() on a namespace


### PR DESCRIPTION
...et process.

Socket.disconnect() is expected to cleanup all namespaces attached to the socket. However if the method is called by a process that is attached to the socket, the last namespace is not properly cleaned because the process is killed during the call to remove_namespace and it never gets to call kill_local_jobs. Processes spawned by the namespace are leaked unless they monitor the socket state and exit on disconnect. This happens e.g. when send_into_ws process (in WebsocketTransport) calls socket.disconnect after it fails to send data to the client. Also _heartbeat_timeout process triggers the bug if it times out.
