### PR TITLE
Fix for AttributeError: environ

### DIFF
--- a/socketio/handler.py
+++ b/socketio/handler.py
@@ -201,7 +201,8 @@ class SocketIOHandler(WSGIHandler):
 
         # Clean up circular references so they can be garbage collected.
         if hasattr(self, 'websocket') and self.websocket:
-            del self.websocket.environ
+            if self.websocket.environ:
+                del self.websocket.environ
             del self.websocket
         if self.environ:
             del self.environ


### PR DESCRIPTION
Seeing this in the logs:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/gevent/greenlet.py", line 390, in run
    result = self._run(*self.args, **self.kwargs)
  File "/usr/local/lib/python2.7/site-packages/gevent_socketio-0.3.6-py2.7.egg/socketio/server.py", line 124, in handle
    handler.handle()
  File "/usr/local/lib/python2.7/site-packages/gevent/pywsgi.py", line 180, in handle
    result = self.handle_one_request()
  File "/usr/local/lib/python2.7/site-packages/gevent/pywsgi.py", line 314, in handle_one_request
    self.handle_one_response()
  File "/usr/local/lib/python2.7/site-packages/gevent_socketio-0.3.6-py2.7.egg/socketio/handler.py", line 184, in handle_one_response
    del self.websocket.environ
AttributeError: environ
<Greenlet at 0x31244b0: <bound method SocketIOServer.handle of <SocketIOServer at 0x3020210 fileno=5 address=127.0.0.1:8027>>(<socket at 0x3016d50 fileno=[Errno 9] Bad file des, ('127.0.0.1', 34349))> failed with AttributeError
```

I don't know if self.websocket.environ should really be deleted (it's not accesses anywhere in the code), but this PR should at least fix the attribute error.
