### PR TITLE
Add requirements for people not using buildout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+gevent==1.0
+gevent-websocket==0.9
+greenlet==0.4.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+-r requirements.txt 
+mock==1.0.1
+pytest==2.5.1
+py==1.4.19


### PR DESCRIPTION
There are plenty people using pip and virtualenv for testing and creating packages. :) Buildout isn't only option. 
