### PR TITLE
removed TypeError-handler for callbacks

### DIFF
--- a/socketio/namespace.py
+++ b/socketio/namespace.py
@@ -26,7 +26,7 @@ class BaseNamespace(object):
 
       def on_my_second_event(self, whatever):
           print "This holds the first arg that was passed", whatever
-T
+
     Handlers are automatically dispatched based on the name of the incoming
     event. For example, a 'user message' event will be handled by
     ``on_user_message()``. To change this, override :meth:`process_event`.


### PR DESCRIPTION
I don't understand, why TypeErrors are handled at callbacks. This exception handler has hidden a TypeError in one of my callback-methods and it was difficult to find the cause. Is it necessary to check whether «callback» is callable? Don't think so, personally: it is a programming error and no runtime error.
