### PR TITLE
Backward compatibility support for Python 2.6 and under

### DIFF
--- a/socketio/virtsocket.py
+++ b/socketio/virtsocket.py
@@ -47,7 +47,7 @@ def default_error_handler(socket, error_name, error_message, endpoint,
         socket.send_packet(pkt)
         
     # Log that error somewhere for debugging...
-    log.error(u"default_error_handler: {}, {} (endpoint={}, msg_id={})".format(
+    log.error(u"default_error_handler: {0}, {1} (endpoint={2}, msg_id={3})".format(
         error_name, error_message, endpoint, msg_id
     ))
 


### PR DESCRIPTION
I see non-zero length field names({0}, {1}, ...) on other codes but somehow zero length field names were in virtsocket.py...
