### PR TITLE
Fixed version of flask-sqlalchemy==0.7.8 in examples/flask_chat/requirements.txt

### DIFF
--- a/examples/flask_chat/requirements.txt
+++ b/examples/flask_chat/requirements.txt
@@ -1,3 +1,3 @@
-flask==0.9
-flask-sqlalchemy==0.7.8
-gevent-socketio==0.3.5-rc2
+flask==0.10.1
+flask-sqlalchemy==2.0
+gevent-socketio==0.3.6


### PR DESCRIPTION
Since `flask-sqlalchemy==0.7.8` didn't exists on PyPI server.
Also updated `gevent-socketio` and `flask` to their latest version.
