### PR TITLE
Fix gevent-websocket import error.

### DIFF
--- a/socketio/transports.py
+++ b/socketio/transports.py
@@ -1,7 +1,10 @@
 import gevent
 import urllib
 import urlparse
-from geventwebsocket import WebSocketError
+try:
+    from geventwebsocket import WebSocketError
+except ImportError:
+    from geventwebsocket.exceptions import WebSocketError
 from gevent.queue import Empty
 
 


### PR DESCRIPTION
WebSocketError has been moved to geventwebsocket.exceptions since 0.3.0.

FYI
https://github.com/jgelens/gevent-websocket/commit/0c00842e9512ed75498e52d4e4a01d5890d1dbd9