### PR TITLE
added missing pyramid_mako to the pyramid examples

### DIFF
--- a/examples/pyramid_backbone_redis_chat/chatter3/__init__.py
+++ b/examples/pyramid_backbone_redis_chat/chatter3/__init__.py
@@ -12,6 +12,8 @@ def simple_route(config, name, url, fn):
 def main(global_config, **settings):
     config = Configurator()
 
+    config.include('pyramid_mako')
+
     simple_route(config, 'index', '/', index)
     simple_route(config, 'socket_io', 'socket.io/*remaining', socketio_service)
 

--- a/examples/pyramid_backbone_redis_chat/setup.py
+++ b/examples/pyramid_backbone_redis_chat/setup.py
@@ -18,6 +18,7 @@ CHANGES = ''
 
 requires = [
     'pyramid'
+    , 'pyramid_mako'
     , 'gevent'
     , 'gevent-socketio'
     , 'pyramid_socketio'

--- a/examples/pyramid_backbone_redis_chat_persistence/chatter4/__init__.py
+++ b/examples/pyramid_backbone_redis_chat_persistence/chatter4/__init__.py
@@ -20,6 +20,7 @@ def simple_route(config, name, url, fn, renderer=None):
 def main(global_config, **settings):
     config = Configurator()
 
+    config.include('pyramid_mako')
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
 

--- a/examples/pyramid_backbone_redis_chat_persistence/setup.py
+++ b/examples/pyramid_backbone_redis_chat_persistence/setup.py
@@ -16,7 +16,7 @@ def _read(path):
 README = ''
 CHANGES = ''
 
-requires = ['pyramid', 'gevent', 'gevent-socketio', 'sqlalchemy', 'redis', 'gunicorn']
+requires = ['pyramid', 'pyramid.mako', 'gevent', 'gevent-socketio', 'sqlalchemy', 'redis', 'gunicorn']
 
 if sys.version_info[:3] < (2, 5, 0):
     requires.append('pysqlite')


### PR DESCRIPTION
Pyramid mako, nowadays, is an external dependency renderer for Pyramid. We should include it on the setup.py and in the configuration of the example.

