### PR TITLE
Fixes unicode error with newest gevent

### DIFF
--- a/socketio/handler.py
+++ b/socketio/handler.py
@@ -74,7 +74,7 @@ class SocketIOHandler(WSGIHandler):
             ("Access-Control-Allow-Origin", self.environ.get('HTTP_ORIGIN', '*')),
             ("Access-Control-Allow-Credentials", "true"),
             ("Access-Control-Allow-Methods", "POST, GET, OPTIONS"),
-            ("Access-Control-Max-Age", 3600),
+            ("Access-Control-Max-Age", "3600"),
             ("Content-Type", "text/plain"),
         ])
         self.result = [data]

--- a/socketio/transports.py
+++ b/socketio/transports.py
@@ -21,7 +21,7 @@ class BaseTransport(object):
             ("Access-Control-Allow-Origin", "*"),
             ("Access-Control-Allow-Credentials", "true"),
             ("Access-Control-Allow-Methods", "POST, GET, OPTIONS"),
-            ("Access-Control-Max-Age", 3600),
+            ("Access-Control-Max-Age", "3600"),
         ]
         self.handler = handler
         self.config = config


### PR DESCRIPTION
Gevent only accepts unicode string as value for headers, otherwise the following error is thrown:

```UnicodeError: ('The value must be a native string', 'Access-Control-Max-Age', 3600)```

This PR fixes this problem.