### PR TITLE
Allow Python logger object to be used for logging

### DIFF
--- a/socketio/handler.py
+++ b/socketio/handler.py
@@ -74,7 +74,7 @@ class SocketIOHandler(WSGIHandler):
             ("Access-Control-Allow-Origin", self.environ.get('HTTP_ORIGIN', '*')),
             ("Access-Control-Allow-Credentials", "true"),
             ("Access-Control-Allow-Methods", "POST, GET, OPTIONS"),
-            ("Access-Control-Max-Age", 3600),
+            ("Access-Control-Max-Age", "3600"),
             ("Content-Type", "text/plain"),
         ])
         self.result = [data]

--- a/socketio/server.py
+++ b/socketio/server.py
@@ -96,7 +96,12 @@ class SocketIOServer(WSGIServer):
 
         log_file = kwargs.pop('log_file', None)
         if log_file:
-            kwargs['log'] = open(log_file, 'a')
+            if hasattr(log_file, 'log'):
+                # logger object
+                kwargs['log'] = log_file
+            else:
+                # file name
+                kwargs['log'] = open(log_file, 'a')
 
         super(SocketIOServer, self).__init__(*args, **kwargs)
 

--- a/socketio/transports.py
+++ b/socketio/transports.py
@@ -21,7 +21,7 @@ class BaseTransport(object):
             ("Access-Control-Allow-Origin", "*"),
             ("Access-Control-Allow-Credentials", "true"),
             ("Access-Control-Allow-Methods", "POST, GET, OPTIONS"),
-            ("Access-Control-Max-Age", 3600),
+            ("Access-Control-Max-Age", "3600"),
         ]
         self.handler = handler
         self.config = config


### PR DESCRIPTION
This PR allows logger object to be specified instead of a file name for gevent WSGIServer logging described here: https://github.com/gevent/gevent/blob/master/gevent/pywsgi.py#L981

I use same criteria here as gevent to determine if it's a logger object:
https://github.com/gevent/gevent/blob/master/gevent/pywsgi.py#L1059