### PR TITLE
Header value required to be a string

### DIFF
--- a/socketio/handler.py
+++ b/socketio/handler.py
@@ -74,7 +74,7 @@ class SocketIOHandler(WSGIHandler):
             ("Access-Control-Allow-Origin", self.environ.get('HTTP_ORIGIN', '*')),
             ("Access-Control-Allow-Credentials", "true"),
             ("Access-Control-Allow-Methods", "POST, GET, OPTIONS"),
-            ("Access-Control-Max-Age", 3600),
+            ("Access-Control-Max-Age", "3600"),
             ("Content-Type", "text/plain"),
         ])
         self.result = [data]


### PR DESCRIPTION
```start_response``` requires that headers titles and values are always strings https://github.com/gevent/gevent/blob/master/gevent/pywsgi.py#L740

In other case exception thrown
```
UnicodeError: ('The value must be a native string', 'Access-Control-Max-Age', 3600)
<Greenlet at 0x10de6e410: _close_when_done(<socket at 0x10e8f0490 fileno=[Errno 9] Bad file d, ('127.0.0.1', 65126))> failed with UnicodeError
```