### PR TITLE
Django 1.9 Compatibility with Fallback for Django 1.8/Python 2.6 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 before_install: "sudo apt-get install python-dev libevent-dev"
 
 # command to install dependencies
-install: pip install nosetests; python setup.py install
+install: pip install nose; python setup.py install
 
 # command to run tests
 script: nosetests

--- a/socketio/sdjango.py
+++ b/socketio/sdjango.py
@@ -3,7 +3,12 @@ import logging
 from socketio import socketio_manage
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.utils.importlib import import_module
+
+# for Django 1.9 support
+try:
+    from django.utils.importlib import import_module
+except ImportError:
+    from importlib import import_module
 
 # for Django 1.3 support
 try:


### PR DESCRIPTION
This fixes issue #234.

I've also fixed a broken `pip install` command in the Travis config so that the build will run for this PR. If you'd like that to be a separate fix, let me know and I can remove it from here.