### PR TITLE
Stop re-raising exception on dead websocket.

### DIFF
--- a/socketio/transports.py
+++ b/socketio/transports.py
@@ -249,9 +249,7 @@ class WebsocketTransport(BaseTransport):
                     break
                 try:
                     websocket.send(message)
-                except (WebSocketError, TypeError) as e:
-                    print(e)
-                    raise
+                except (WebSocketError, TypeError):
                     # We can't send a message on the socket
                     # it is dead, let the other sockets know
                     socket.disconnect()


### PR DESCRIPTION
Re-raising the exception in transports.py means that socket.disconnect() will never be called. This also seems to have the side effect of raising an exception whenever someone doesn't cleanly disconnect the websocket.

It looks like this was added as a part of this commit: 12da9667deba432d8917129afab1daa86c20ec84