### PR TITLE
Setting Content-Length Headers to Strings

### DIFF
--- a/socketio/handler.py
+++ b/socketio/handler.py
@@ -213,7 +213,7 @@ class SocketIOHandler(WSGIHandler):
         self.start_response("400 Bad Request", [
             ('Content-Type', 'text/plain'),
             ('Connection', 'close'),
-            ('Content-Length', 0)
+            ('Content-Length', '0')
         ])
 
 
@@ -222,5 +222,5 @@ class SocketIOHandler(WSGIHandler):
         self.start_response("200 OK", [
             ('Content-Type', 'text/plain'),
             ('Connection', 'close'),
-            ('Content-Length', 0)
+            ('Content-Length', '0')
         ])


### PR DESCRIPTION
This causes a `UnicodeError` in the latest Gevent version.