### PR TITLE
Django 1.10 Support

### DIFF
--- a/socketio/sdjango.py
+++ b/socketio/sdjango.py
@@ -1,6 +1,8 @@
 import logging
 
 from socketio import socketio_manage
+import django
+from django.conf.urls import url
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
@@ -10,8 +12,6 @@ try:
 except ImportError:
     # Django versions < 1.9
     from django.utils.importlib import import_module
-
-from django.conf.urls import patterns, url, include
 
 
 SOCKETIO_NS = {}
@@ -69,4 +69,8 @@ def socketio(request):
     return HttpResponse("")
 
 
-urls = patterns("", (r'', socketio))
+if django.VERSION >= (1, 8,):
+    urls = [url(r'', socketio)]
+else:
+    from django.conf.urls import patterns
+    urls = patterns("", (r'', socketio))

--- a/socketio/sdjango.py
+++ b/socketio/sdjango.py
@@ -11,11 +11,7 @@ except ImportError:
     # Django versions < 1.9
     from django.utils.importlib import import_module
 
-# for Django 1.3 support
-try:
-    from django.conf.urls import patterns, url, include
-except ImportError:
-    from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 
 
 SOCKETIO_NS = {}
@@ -24,7 +20,6 @@ SOCKETIO_NS = {}
 LOADING_SOCKETIO = False
 
 
-        
 def autodiscover():
     """
     Auto-discover INSTALLED_APPS sockets.py modules and fail silently when
@@ -59,11 +54,10 @@ def autodiscover():
 class namespace(object):
     def __init__(self, name=''):
         self.name = name
- 
+
     def __call__(self, handler):
         SOCKETIO_NS[self.name] = handler
         return handler
-
 
 
 @csrf_exempt


### PR DESCRIPTION
- Add support for Django 1.10
- Drop support for Django 1.3

This PR resolves https://github.com/abourget/gevent-socketio/issues/245.