### PR TITLE
Fix mako incopatibilitie on pyramid chat example

### DIFF
--- a/examples/simple_pyramid_chat/chatter2/__init__.py
+++ b/examples/simple_pyramid_chat/chatter2/__init__.py
@@ -17,6 +17,7 @@ def simple_route(config, name, url, fn):
 
 def main(global_config, **settings):
     config = Configurator()
+    config.include('pyramid_mako')
 
     simple_route(config, 'index', '/', index)
 

--- a/examples/simple_pyramid_chat/setup.py
+++ b/examples/simple_pyramid_chat/setup.py
@@ -20,6 +20,7 @@ requires = [
     'pyramid'
     , 'gevent-socketio'
     , 'gevent-websocket'
+    , 'pyramid_mako'
 ]
 
 if sys.version_info[:3] < (2, 5, 0):


### PR DESCRIPTION
New Pyramid's version no longer support .mako (so as .chameleon) natively. 

More informations: https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-1.5.html

Because of this, when you try to run the simple_pyramid_chat example you get an error.
So, I updated the Pyramid example to support .mako (just putting him on the dependencies).

This error is mentioned in issue #189 