### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/live_cpu_graph/live_cpu_graph/static/excanvas.js
+++ b/examples/live_cpu_graph/live_cpu_graph/static/excanvas.js
@@ -49,7 +49,7 @@ if (!document.createElement('canvas').getContext) {
   var Z2 = Z / 2;
 
   /**
-   * This funtion is assigned to the <canvas> elements as element.getContext().
+   * This function is assigned to the <canvas> elements as element.getContext().
    * @this {HTMLElement}
    * @return {CanvasRenderingContext2D_}
    */

--- a/examples/pyramid_backbone_redis_chat/chatter3/static/backbone.js
+++ b/examples/pyramid_backbone_redis_chat/chatter3/static/backbone.js
@@ -990,7 +990,7 @@
     tagName: 'div',
 
     // jQuery delegate for element lookup, scoped to DOM elements within the
-    // current view. This should be prefered to global lookups where possible.
+    // current view. This should be preferred to global lookups where possible.
     $: function(selector) {
       return this.$el.find(selector);
     },

--- a/examples/pyramid_backbone_redis_chat/chatter3/static/handlebars.js
+++ b/examples/pyramid_backbone_redis_chat/chatter3/static/handlebars.js
@@ -236,7 +236,7 @@ parse: function parse(input) {
 
     var symbol, preErrorSymbol, state, action, a, r, yyval={},p,len,newState, expected;
     while (true) {
-        // retreive state number from top of stack
+        // retrieve state number from top of stack
         state = stack[stack.length-1];
 
         // use default actions if available

--- a/examples/pyramid_backbone_redis_chat_persistence/chatter4/static/backbone.js
+++ b/examples/pyramid_backbone_redis_chat_persistence/chatter4/static/backbone.js
@@ -990,7 +990,7 @@
     tagName: 'div',
 
     // jQuery delegate for element lookup, scoped to DOM elements within the
-    // current view. This should be prefered to global lookups where possible.
+    // current view. This should be preferred to global lookups where possible.
     $: function(selector) {
       return this.$el.find(selector);
     },

--- a/examples/pyramid_backbone_redis_chat_persistence/chatter4/static/handlebars.js
+++ b/examples/pyramid_backbone_redis_chat_persistence/chatter4/static/handlebars.js
@@ -236,7 +236,7 @@ parse: function parse(input) {
 
     var symbol, preErrorSymbol, state, action, a, r, yyval={},p,len,newState, expected;
     while (true) {
-        // retreive state number from top of stack
+        // retrieve state number from top of stack
         state = stack[stack.length-1];
 
         // use default actions if available

--- a/examples/simple_pyramid_chat/chatter2/static/backbone.js
+++ b/examples/simple_pyramid_chat/chatter2/static/backbone.js
@@ -990,7 +990,7 @@
     tagName: 'div',
 
     // jQuery delegate for element lookup, scoped to DOM elements within the
-    // current view. This should be prefered to global lookups where possible.
+    // current view. This should be preferred to global lookups where possible.
     $: function(selector) {
       return this.$el.find(selector);
     },

--- a/examples/simple_pyramid_chat/chatter2/static/handlebars.js
+++ b/examples/simple_pyramid_chat/chatter2/static/handlebars.js
@@ -236,7 +236,7 @@ parse: function parse(input) {
 
     var symbol, preErrorSymbol, state, action, a, r, yyval={},p,len,newState, expected;
     while (true) {
-        // retreive state number from top of stack
+        // retrieve state number from top of stack
         state = stack[stack.length-1];
 
         // use default actions if available

--- a/examples/testapp/testapp/static/backbone.js
+++ b/examples/testapp/testapp/static/backbone.js
@@ -990,7 +990,7 @@
     tagName: 'div',
 
     // jQuery delegate for element lookup, scoped to DOM elements within the
-    // current view. This should be prefered to global lookups where possible.
+    // current view. This should be preferred to global lookups where possible.
     $: function(selector) {
       return this.$el.find(selector);
     },

--- a/examples/testapp/testapp/static/handlebars.js
+++ b/examples/testapp/testapp/static/handlebars.js
@@ -236,7 +236,7 @@ parse: function parse(input) {
 
     var symbol, preErrorSymbol, state, action, a, r, yyval={},p,len,newState, expected;
     while (true) {
-        // retreive state number from top of stack
+        // retrieve state number from top of stack
         state = stack[stack.length-1];
 
         // use default actions if available

--- a/socketio/virtsocket.py
+++ b/socketio/virtsocket.py
@@ -370,7 +370,7 @@ class Socket(object):
                 continue
 
             if pkt['type'] == 'heartbeat':
-                # This is already dealth with in put_server_msg() when
+                # This is already dealt with in put_server_msg() when
                 # any incoming raw data arrives.
                 continue
 

--- a/tests/jstests/static/qunit.js
+++ b/tests/jstests/static/qunit.js
@@ -1024,7 +1024,7 @@ addEvent( window, "load", QUnit.load );
 onErrorFnPrev = window.onerror;
 
 // Cover uncaught exceptions
-// Returning true will surpress the default browser handler,
+// Returning true will suppress the default browser handler,
 // returning false will let it run.
 window.onerror = function ( error, filePath, linerNr ) {
 	var ret = false;


### PR DESCRIPTION
There are small typos in:
- examples/live_cpu_graph/live_cpu_graph/static/excanvas.js
- examples/pyramid_backbone_redis_chat/chatter3/static/backbone.js
- examples/pyramid_backbone_redis_chat/chatter3/static/handlebars.js
- examples/pyramid_backbone_redis_chat_persistence/chatter4/static/backbone.js
- examples/pyramid_backbone_redis_chat_persistence/chatter4/static/handlebars.js
- examples/simple_pyramid_chat/chatter2/static/backbone.js
- examples/simple_pyramid_chat/chatter2/static/handlebars.js
- examples/testapp/testapp/static/backbone.js
- examples/testapp/testapp/static/handlebars.js
- socketio/virtsocket.py
- tests/jstests/static/qunit.js

Fixes:
- Should read `retrieve` rather than `retreive`.
- Should read `preferred` rather than `prefered`.
- Should read `suppress` rather than `surpress`.
- Should read `function` rather than `funtion`.
- Should read `dealt` rather than `dealth`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md